### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import { SocketProvider } from 'use-phoenix-channel'
 
 const Root = (props) => {
  return (
-   <SocketProvider wsUrl='localhost:4000/socket', options={{ token }}>
+   <SocketProvider wsUrl='/socket' options={{ token }}>
      <App />
    </SocketProvider>
   )
@@ -28,6 +28,8 @@ const Root = (props) => {
 
 export default Root
 ```
+
+The `options` prop is simply passed along as `params` to the underlying Phoenix `Socket` constructor.
 
 ## `useChannel` Hook
 


### PR DESCRIPTION
I found it a bit confusing and wasn't sure whether the `options` prop configured the `Socket` itself, or was just the `params` sent on connecting. Turns out it's just the params:

```javascript
const socket = new Socket(wsUrl, { params: options })
```

I would consider updating the name of the `options` prop to `params` in the future to avoid this confusion, and/or allow configuration of the `Socket` itself using [these props](https://hexdocs.pm/phoenix/js/#socket). I can make a PR if desired.